### PR TITLE
added default error page for /error url

### DIFF
--- a/src/main/java/app/controller/DefaultController.java
+++ b/src/main/java/app/controller/DefaultController.java
@@ -112,5 +112,10 @@ public class DefaultController {
         return "login";
     }
 
+    @GetMapping("/error")
+    public String error(){
+        return "error";
+    }
+
 
 }

--- a/src/main/java/app/security/CustomLoginSuccessHandler.java
+++ b/src/main/java/app/security/CustomLoginSuccessHandler.java
@@ -11,11 +11,14 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import app.controller.DefaultController;
 import app.model.IncorrectLogin;
 import app.model.User;
 import app.repository.IncorrectLoginRepo;
 import app.repository.UserRepository;
 import app.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
@@ -29,6 +32,8 @@ import org.springframework.stereotype.Component;
 // Adapted from https://www.codejava.net/frameworks/spring-boot/spring-security-limit-login-attempts-example
 @Component
 public class CustomLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultController.class);
 
     @Autowired
     private UserService userService;
@@ -78,6 +83,8 @@ public class CustomLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         if (user.getFailedAttempt() > 0) {
             userService.resetFailedAttempts(user.getEmail());
         }
+
+        logger.info("Successful login, email: " + user.getEmail() + " | ip address: " + ipAddress);
 
         super.onAuthenticationSuccess(request, response, authentication);
     }

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Error</title>
+  <link th:href="@{/css/style-other.css}" rel="stylesheet" />
+</head>
+<body>
+<div style="text-align: center; margin: 18rem auto">
+    <h2>Woops, something went wrong!</h2>
+    <div th:if="${param.error}">
+        <p class="text-danger">[[${session.SPRING_SECURITY_LAST_EXCEPTION.message}]]</p>
+    </div>
+    <h3>Try reloading the site, or logging out and back in :) </h3>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This should patch the cracks not covered by all our other exception handling, so that unforeseen errors do not throw a whitelabel traceback to the user.